### PR TITLE
Add SZ_INCLUDE_FEATURE_HASHES flag definition

### DIFF
--- a/szflags.json
+++ b/szflags.json
@@ -70,6 +70,18 @@
         ]
     },
     {
+        "symbol": "SZ_INCLUDE_FEATURE_HASHES",
+        "altSymbol": "SzIncludeFeatureHashes",
+        "value": 2199023255552,
+        "hexValue": "0x0000020000000000",
+        "bits": [
+            41
+        ],
+        "definition": "1 << 41",
+        "groups": [],
+        "altGroups": []
+    },
+    {
         "symbol": "SZ_EXPORT_INCLUDE_MULTI_RECORD_ENTITIES",
         "altSymbol": "SzExportIncludeMultiRecordEntities",
         "value": 1,


### PR DESCRIPTION
## Summary

- Add `SZ_INCLUDE_FEATURE_HASHES` flag (bit 41, value `0x0000020000000000`) to `szflags.json`
- This flag enables inclusion of feature hashes in feature scores for cross-call feature identification

Resolves senzing-garage/sz-sdk-flags#27
Parent issue: senzing-garage/garage-roadmap#71

🤖 Generated with [Claude Code](https://claude.com/claude-code)